### PR TITLE
simulate_aig_full and counterexample.

### DIFF
--- a/src/classical/abc/functions/abc_cec.cpp
+++ b/src/classical/abc/functions/abc_cec.cpp
@@ -138,7 +138,7 @@ boost::optional< counterexample_t > abc_cec( const aig_graph& circuit, const aig
     /* re-simulate the counterexample */
     auto node_value_map = node_value_map_from_counterexample( circuit, cec_counterexample );
     simple_node_assignment_resimulator sim( node_value_map );
-    auto result = simulate_aig( circuit, sim, settings );
+    auto result = simulate_aig_full( circuit, sim, settings );
 
     counterexample_t cex( _num_vertices - 1u, num_outputs );
 

--- a/src/classical/utils/counterexample.hpp
+++ b/src/classical/utils/counterexample.hpp
@@ -57,6 +57,11 @@ struct assignment_t
     , mask( std::string( assignment.size(), '1' ) )
   {}
 
+  bool operator==( const assignment_t& other ) const
+  {
+    return ( bits == other.bits && mask == other.mask );
+  }
+  
   unsigned size() const
   {
     assert( bits.size() == mask.size() );


### PR DESCRIPTION
bugfix for assignment re-simulated within abc_cec.
simulate_aig_full: considering POs and all nodes without incoming edges.
counterexample.
