### PR TITLE
Fix abc_cli.cpp so it builds

### DIFF
--- a/programs/core/abc_cli.cpp
+++ b/programs/core/abc_cli.cpp
@@ -81,7 +81,7 @@ inline bool store_can_read_io_type<abc::Gia_Man_t*, io_aiger_tag_t>( command& cm
 template<>
 inline abc::Gia_Man_t* store_read_io_type<abc::Gia_Man_t*, io_aiger_tag_t>( const std::string& filename, const command& cmd )
 {
-  return abc::Gia_AigerRead( (char*)filename.c_str(), 0, 0 );
+  return abc::Gia_AigerRead( (char*)filename.c_str(), 0, 0, 0 );
 }
 
 /* enable `write_aiger` for AIGs */


### PR DESCRIPTION
The `abc::Gia_AigerRead` function [takes four arguments](https://github.com/openfpga/abc/blob/c01fe7cd9bb491a092e9a12fa90d28d9a2740b82/src/aig/gia/giaAiger.c#L876), even though the fourth one (`fCheck`) is only passed to `abc::Gia_AigerReadFromMemory` and then [not used at all](https://github.com/openfpga/abc/blob/c01fe7cd9bb491a092e9a12fa90d28d9a2740b82/src/aig/gia/giaAiger.c#L821-L829). Still, this causes `make revkit` to fail, as `abc_cli.cpp` doesn’t build.

As a fix I passed `0` for `fCheck`, which seems as good of a value as any (and used in the vast majority of other `abc::Gia_AigerRead` calls).