### PR TITLE
simulation_graph: remove edge_lookup property map

### DIFF
--- a/src/classical/functions/simulation_graph.cpp
+++ b/src/classical/functions/simulation_graph.cpp
@@ -56,7 +56,6 @@ simulation_graph create_simulation_graph( const aig_graph& aig, const std::vecto
                                           const properties::ptr& settings, const properties::ptr& statistics )
 {
   simulation_graph g;
-  auto& edge_lookup             = boost::get_property( g, boost::graph_edge_lookup );
   auto& meta                    = boost::get_property( g, boost::graph_meta );
   const auto& vertex_in_degree  = boost::get( boost::vertex_in_degree, g );
   const auto& vertex_out_degree = boost::get( boost::vertex_out_degree, g );
@@ -91,13 +90,10 @@ simulation_graph create_simulation_graph( const aig_graph& aig, const std::vecto
   /* add vertices */
   const auto vertices_count = n + m + sim_vectors.size();
   add_vertices( g, vertices_count );
-  edge_lookup.reserve( vertices_count << 5u );
 
   /* edge inserting */
   const auto add_edge_func = [&]( unsigned from, unsigned to ) {
     auto e = add_edge( from, to, g ).first;
-    edge_lookup.insert( std::make_pair( std::make_pair( from, to ), e ) );
-    edge_lookup.insert( std::make_pair( std::make_pair( to, from ), e ) );
     vertex_in_degree[to]++;
     vertex_out_degree[from]++;
     return e;
@@ -146,8 +142,6 @@ simulation_graph create_simulation_graph( const aig_graph& aig, const std::vecto
         const auto from = n + i;
         const auto to = n + sim_vectors.size() + j;
         auto e = add_edge( from, to, g ).first;
-        edge_lookup.insert( std::make_pair( std::make_pair( from, to ), e ) );
-        edge_lookup.insert( std::make_pair( std::make_pair( to, from ), e ) );
         vertex_in_degree[to]++;
         vertex_out_degree[from]++;
 

--- a/src/classical/functions/simulation_graph.hpp
+++ b/src/classical/functions/simulation_graph.hpp
@@ -57,9 +57,6 @@
 namespace boost
 {
 
-enum graph_edge_lookup_t { graph_edge_lookup };
-BOOST_INSTALL_PROPERTY(graph, edge_lookup);
-
 enum graph_meta_t { graph_meta };
 BOOST_INSTALL_PROPERTY(graph, meta);
 
@@ -91,23 +88,10 @@ namespace cirkit
 
 using vertex_pair_t    = std::pair<unsigned, unsigned>;
 
-struct edge_lookup_hash_t
-{
-  inline std::size_t operator()( const vertex_pair_t& p ) const
-  {
-    std::size_t seed = 0;
-    boost::hash_combine( seed, p.first );
-    boost::hash_combine( seed, p.second );
-    return seed;
-  }
-};
-
 namespace detail
 {
   using simulation_graph_traits_t          = boost::adjacency_list_traits<boost::vecS, boost::vecS, boost::undirectedS>;
 }
-
-using edge_lookup_t                        = std::unordered_map<vertex_pair_t, detail::simulation_graph_traits_t::edge_descriptor, edge_lookup_hash_t>;
 
 struct simulation_graph_meta_t
 {
@@ -123,8 +107,7 @@ using simulation_signature_t               = boost::optional<std::vector<unsigne
 /* In order to allow an O(1) lookup for edges in the graph, this
  * edge lookup table is added as a property to the simulation graph
  */
-using simulation_graph_properties_t        = boost::property<boost::graph_meta_t, simulation_graph_meta_t,
-                                             boost::property<boost::graph_edge_lookup_t, edge_lookup_t>>;
+using simulation_graph_properties_t        = boost::property<boost::graph_meta_t, simulation_graph_meta_t>;
 
 /* In order to allow an O(1) access to the vertex in- and out-degree,
  * they are stored additionally as property maps for the vertices.


### PR DESCRIPTION
It is not used anywhere and often dominates run time.

The solution turned out to be easier than I expected - remove instead of optimizing. Atleast on the example we profiled, this change reduces the time it takes to construct the graph to negligible levels.

Baruch