### PR TITLE
Signal name preservation for `lut_resynthesis`

### DIFF
--- a/cli/algorithms/cut_rewrite.hpp
+++ b/cli/algorithms/cut_rewrite.hpp
@@ -107,7 +107,7 @@ public:
         mockturtle::exact_resynthesis_params esps;
         esps.cache = exact_aig_cache;
         esps.conflict_limit = conflict_limit;
-        mockturtle::exact_aig_resynthesis resyn( esps );
+        mockturtle::exact_aig_resynthesis resyn( false, esps );
         mockturtle::cut_rewriting( *aig_p, resyn, ps, &st );
         *aig_p = cleanup_dangling( *aig_p );
       }

--- a/cli/algorithms/exact.hpp
+++ b/cli/algorithms/exact.hpp
@@ -41,7 +41,7 @@ public:
       mockturtle::exact_resynthesis_params esps;
       esps.cache = exact_aig_cache;
       esps.conflict_limit = conflict_limit;
-      mockturtle::exact_aig_resynthesis resyn( esps );
+      mockturtle::exact_aig_resynthesis resyn( false, esps );
 
       mockturtle::aig_network ntk;
       std::vector<mockturtle::aig_network::signal> pis( tt.num_vars() );

--- a/cli/algorithms/lut_resynthesis.hpp
+++ b/cli/algorithms/lut_resynthesis.hpp
@@ -32,13 +32,19 @@ public:
       case 0:
       {
         mockturtle::mig_npn_resynthesis resyn;
-        return mockturtle::node_resynthesis<mockturtle::mig_network>( ntk, resyn );
+        mockturtle::mig_network mig;
+        mockturtle::names_view<mockturtle::mig_network> named_mig( mig );
+        mockturtle::node_resynthesis( named_mig, ntk, resyn );
+        return named_mig;
       }
       break;
       case 1:
       {
         mockturtle::akers_resynthesis<mockturtle::mig_network> resyn;
-        return mockturtle::node_resynthesis<mockturtle::mig_network>( ntk, resyn );
+        mockturtle::mig_network mig;
+        mockturtle::names_view<mockturtle::mig_network> named_mig( mig );
+        mockturtle::node_resynthesis( named_mig, ntk, resyn );
+        return named_mig;
       }
       }
     }();

--- a/cli/stores/mig.hpp
+++ b/cli/stores/mig.hpp
@@ -16,7 +16,7 @@
 namespace alice
 {
 
-using mig_nt = mockturtle::mapping_view<mockturtle::mig_network, true>;
+using mig_nt = mockturtle::mapping_view<mockturtle::names_view<mockturtle::mig_network>, true>;
 using mig_t = std::shared_ptr<mig_nt>;
 
 ALICE_ADD_STORE( mig_t, "mig", "m", "MIG", "MIGs" );
@@ -86,6 +86,11 @@ ALICE_READ_FILE( mig_t, verilog, filename, cmd )
 ALICE_WRITE_FILE( mig_t, verilog, mig, filename, cmd )
 {
   mockturtle::write_verilog( *mig, filename );
+}
+
+ALICE_WRITE_FILE( mig_t, blif, mig, filename, cmd )
+{
+  mockturtle::write_blif( *mig, filename );
 }
 
 } // namespace alice


### PR DESCRIPTION
This PR integrates `names_view` into MIG store and enables input and output signal preservation for the command `lut_resynthesis`.