### PR TITLE
names_view and repeat-flag

### DIFF
--- a/cli/stores/aig.hpp
+++ b/cli/stores/aig.hpp
@@ -8,6 +8,7 @@
 #include <mockturtle/io/blif_reader.hpp>
 #include <mockturtle/io/verilog_reader.hpp>
 #include <mockturtle/io/write_bench.hpp>
+#include <mockturtle/io/write_blif.hpp>
 #include <mockturtle/io/write_verilog.hpp>
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/views/depth_view.hpp>
@@ -83,6 +84,11 @@ ALICE_READ_FILE( aig_t, verilog, filename, cmd )
 ALICE_WRITE_FILE( aig_t, verilog, aig, filename, cmd )
 {
   mockturtle::write_verilog( *aig, filename );
+}
+
+ALICE_WRITE_FILE( aig_t, blif, aig, filename, cmd )
+{
+  mockturtle::write_blif( *aig, filename );
 }
 
 } // namespace alice

--- a/cli/stores/aig.hpp
+++ b/cli/stores/aig.hpp
@@ -12,13 +12,14 @@
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/views/depth_view.hpp>
 #include <mockturtle/views/mapping_view.hpp>
+#include <mockturtle/views/names_view.hpp>
 
 #include <fmt/format.h>
 
 namespace alice
 {
 
-using aig_nt = mockturtle::mapping_view<mockturtle::aig_network, true>;
+using aig_nt = mockturtle::mapping_view<mockturtle::names_view<mockturtle::aig_network>, true>;
 using aig_t = std::shared_ptr<aig_nt>;
 
 ALICE_ADD_STORE( aig_t, "aig", "a", "AIG", "AIGs" );

--- a/cli/stores/mig.hpp
+++ b/cli/stores/mig.hpp
@@ -10,6 +10,7 @@
 #include <mockturtle/networks/mig.hpp>
 #include <mockturtle/views/depth_view.hpp>
 #include <mockturtle/views/mapping_view.hpp>
+#include <mockturtle/views/names_view.hpp>
 
 #include <fmt/format.h>
 

--- a/cli/stores/xag.hpp
+++ b/cli/stores/xag.hpp
@@ -8,13 +8,14 @@
 #include <mockturtle/networks/xag.hpp>
 #include <mockturtle/views/depth_view.hpp>
 #include <mockturtle/views/mapping_view.hpp>
+#include <mockturtle/views/names_view.hpp>
 
 #include <fmt/format.h>
 
 namespace alice
 {
 
-using xag_nt = mockturtle::mapping_view<mockturtle::xag_network, true>;
+using xag_nt = mockturtle::mapping_view<mockturtle::names_view<mockturtle::xag_network>, true>;
 using xag_t = std::shared_ptr<xag_nt>;
 
 ALICE_ADD_STORE( xag_t, "xag", "", "XAG", "XAGs" );

--- a/cli/stores/xag.hpp
+++ b/cli/stores/xag.hpp
@@ -4,6 +4,7 @@
 #include <lorina/verilog.hpp>
 #include <mockturtle/io/verilog_reader.hpp>
 #include <mockturtle/io/write_bench.hpp>
+#include <mockturtle/io/write_blif.hpp>
 #include <mockturtle/io/write_verilog.hpp>
 #include <mockturtle/networks/xag.hpp>
 #include <mockturtle/views/depth_view.hpp>
@@ -80,6 +81,11 @@ ALICE_READ_FILE( xag_t, verilog, filename, cmd )
 ALICE_WRITE_FILE( xag_t, verilog, xag, filename, cmd )
 {
   mockturtle::write_verilog( *xag, filename );
+}
+
+ALICE_WRITE_FILE( xag_t, blif, xag, filename, cmd )
+{
+  mockturtle::write_blif( *xag, filename );
 }
 
 } // namespace alice

--- a/cli/stores/xmg.hpp
+++ b/cli/stores/xmg.hpp
@@ -6,6 +6,7 @@
 #include <mockturtle/io/aiger_reader.hpp>
 #include <mockturtle/io/verilog_reader.hpp>
 #include <mockturtle/io/write_bench.hpp>
+#include <mockturtle/io/write_blif.hpp>
 #include <mockturtle/io/write_verilog.hpp>
 #include <mockturtle/networks/xmg.hpp>
 #include <mockturtle/views/depth_view.hpp>
@@ -87,6 +88,11 @@ ALICE_READ_FILE( xmg_t, verilog, filename, cmd )
 ALICE_WRITE_FILE( xmg_t, verilog, xmg, filename, cmd )
 {
   mockturtle::write_verilog( *xmg, filename );
+}
+
+ALICE_WRITE_FILE( xmg_t, blif, xmg, filename, cmd )
+{
+  mockturtle::write_blif( *xmg, filename );
 }
 
 } // namespace alice

--- a/cli/stores/xmg.hpp
+++ b/cli/stores/xmg.hpp
@@ -10,13 +10,14 @@
 #include <mockturtle/networks/xmg.hpp>
 #include <mockturtle/views/depth_view.hpp>
 #include <mockturtle/views/mapping_view.hpp>
+#include <mockturtle/views/names_view.hpp>
 
 #include <fmt/format.h>
 
 namespace alice
 {
 
-using xmg_nt = mockturtle::mapping_view<mockturtle::xmg_network, true>;
+using xmg_nt = mockturtle::mapping_view<mockturtle::names_view<mockturtle::xmg_network>, true>;
 using xmg_t = std::shared_ptr<xmg_nt>;
 
 ALICE_ADD_STORE( xmg_t, "xmg", "x", "XMG", "XMGs" );


### PR DESCRIPTION
This PR extends the stores for AIGs, MIGs, XAGs, and XMGs with `names_view` and adds a flag to `cut_rewrite` to repeat the algorithm until convergence.